### PR TITLE
Fully clear skin in clearSkin method. Fixes #53

### DIFF
--- a/src/main/java/org/samo_lego/fabrictailor/mixin/ServerPlayerEntityMixin_TailoredPlayer.java
+++ b/src/main/java/org/samo_lego/fabrictailor/mixin/ServerPlayerEntityMixin_TailoredPlayer.java
@@ -156,6 +156,9 @@ public class ServerPlayerEntityMixin_TailoredPlayer implements TailoredPlayer  {
     public void clearSkin() {
         try {
             this.map.removeAll("textures");
+            // Ensure that the skin is completely cleared to prevent the save bug.
+            this.skinValue = null;
+            this.skinSignature = null;
             this.reloadSkin();
         } catch (Exception ignored) {
             // Player has no skin data, no worries


### PR DESCRIPTION
Simple fix that clears the skin value & signature fields in the tailored player mixin.

Fixes #53