### PR TITLE
Allow selectors in `/skin set player`

### DIFF
--- a/src/main/java/org/samo_lego/fabrictailor/mixin/accessors/AEntitySelector.java
+++ b/src/main/java/org/samo_lego/fabrictailor/mixin/accessors/AEntitySelector.java
@@ -1,0 +1,13 @@
+package org.samo_lego.fabrictailor.mixin.accessors;
+
+import net.minecraft.commands.arguments.selector.EntitySelector;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(EntitySelector.class)
+public interface AEntitySelector {
+
+    @Accessor
+    String getPlayerName();
+
+}

--- a/src/main/resources/fabrictailor.mixins.json
+++ b/src/main/resources/fabrictailor.mixins.json
@@ -1,23 +1,24 @@
 {
-  "required": true,
-  "minVersion": "0.8",
-  "package": "org.samo_lego.fabrictailor.mixin",
-  "compatibilityLevel": "JAVA_16",
-  "client": [
-    "accessors.client.AAdvancementsScreen",
-    "client.AAbstractClientPlayer",
-    "client.MHttpTexture_HDEnabler",
-    "client.MSkinCustomizationScreen",
-    "client.MTextureUrlChecker_AllDomains",
-    "client.MYggDrasilMinecraftSessionService_AllSkinsAcceptor"
-  ],
-  "mixins": [
-    "MServerPlayerEntity_TailoredPlayer",
-    "accessors.AChunkMap",
-    "accessors.APlayer",
-    "accessors.ATrackedEntity"
-  ],
-  "injectors": {
-    "defaultRequire": 1
+    "required": true,
+    "minVersion": "0.8",
+    "package": "org.samo_lego.fabrictailor.mixin",
+    "compatibilityLevel": "JAVA_16",
+    "client": [
+        "accessors.client.AAdvancementsScreen",
+        "client.AAbstractClientPlayer",
+        "client.MHttpTexture_HDEnabler",
+        "client.MSkinCustomizationScreen",
+        "client.MTextureUrlChecker_AllDomains",
+        "client.MYggDrasilMinecraftSessionService_AllSkinsAcceptor"
+    ],
+    "mixins": [
+        "MServerPlayerEntity_TailoredPlayer",
+        "accessors.AChunkMap",
+        "accessors.AEntitySelector",
+        "accessors.APlayer",
+        "accessors.ATrackedEntity"
+    ],
+    "injectors": {
+        "defaultRequire": 1
   }
 }


### PR DESCRIPTION
This PR changes the `/skin set player` sub-command to make it accept either a username of a player (online or offline) or a target selector limited to a single player.

I apologize in advance if the code is not that great, but the only method I can think of for allowing input of offline player usernames is to use an accessor to get the player name from the `EntitySelector`, which will be `null` if the user were to input a target selector