### PR TITLE
Move Fabric Tailor From 1.21.4 To 1.21.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.8.9'
+    id 'fabric-loom' version '1.10.1'
     id 'maven-publish'
     id "com.matthewprenger.cursegradle" version "1.4.0"
     id "com.modrinth.minotaur" version "2.+"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,18 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.16.10
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
+loader_version=0.16.13
 
 # Fabric API
-fabric_version=0.115.0+1.21.4
+fabric_version=0.119.9+1.21.5
 # Mod Properties
-mod_version=2.6.3
+mod_version=2.6.4
 maven_group=org.samo_lego
 archives_base_name=fabrictailor
 
 # Dependencies
 c2b_lib_version=2.0.1
-carpet_core_version=1.21.4-1.4.161+v241203
+carpet_core_version=1.21.5-1.4.169+v250325
 permissions_api_version=0.3.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/samo_lego/fabrictailor/client/screen/SkinChangeScreen.java
+++ b/src/main/java/org/samo_lego/fabrictailor/client/screen/SkinChangeScreen.java
@@ -231,7 +231,6 @@ public class SkinChangeScreen extends Screen {
         this.startY = (this.height - 140) / 2;
 
         // Window texture
-        RenderSystem.enableBlend();
         guiGraphics.blit(RenderType::guiTextured, AdvancementsScreen.WINDOW_LOCATION, startX, startY, 0, 0, 252, 140, 256, 256);
 
 

--- a/src/main/java/org/samo_lego/fabrictailor/mixin/MServerPlayerEntity_TailoredPlayer.java
+++ b/src/main/java/org/samo_lego/fabrictailor/mixin/MServerPlayerEntity_TailoredPlayer.java
@@ -137,7 +137,7 @@ public abstract class MServerPlayerEntity_TailoredPlayer extends Player implemen
         );
 
         this.connection.send(new ClientboundPlayerPositionPacket(0, PositionMoveRotation.of(self), Collections.emptySet()));
-        this.connection.send(new ClientboundSetCursorItemPacket(this.getInventory().getSelected()));
+        this.connection.send(new ClientboundSetCursorItemPacket(this.getInventory().getSelectedItem()));
 
         this.connection.send(new ClientboundChangeDifficultyPacket(level.getDifficulty(), level.getLevelData().isDifficultyLocked()));
         this.connection.send(new ClientboundSetExperiencePacket(this.experienceProgress, this.totalExperience, this.experienceLevel));
@@ -326,12 +326,16 @@ public abstract class MServerPlayerEntity_TailoredPlayer extends Player implemen
 
     @Inject(method = "readAdditionalSaveData", at = @At("TAIL"))
     private void readCustomDataFromNbt(CompoundTag tag, CallbackInfo ci) {
-        CompoundTag skinDataTag = tag.getCompound("fabrictailor:skin_data");
-        this.skinValue = skinDataTag.contains("value") ? skinDataTag.getString("value") : null;
-        this.skinSignature = skinDataTag.contains("signature") ? skinDataTag.getString("signature") : null;
-
-        if (this.skinValue != null) {
-            this.fabrictailor_setSkin(this.skinValue, this.skinSignature, false);
+        CompoundTag skinDataTag = tag.getCompound("fabrictailor:skin_data").get();
+        Optional<String> skinValueOP = skinDataTag.getString("value");
+        Optional<String> skinSignatureOP = skinDataTag.getString("signature");
+        // https://fabricmc.net/2025/03/24/1215.html#nbt
+        if (skinValueOP.isEmpty() || skinSignatureOP.isEmpty()) {
+            return;
         }
+
+        this.skinValue = skinValueOP.get();
+        this.skinSignature = skinSignatureOP.get();
+        this.fabrictailor_setSkin(this.skinValue, this.skinSignature, false);
     }
 }


### PR DESCRIPTION
# Description
**Currently, fabric tailor uses 1.21.4, which fabric allows support for in 1.21.5 but unfortunately a major change happened for NbtCompounds and it caused fabric tailor to not allow players to join more than once in an server. Making the server completely unplayable.** 
This is an very critical bug, not even allowing an player to join without restarting the server. So I've managed to make an working transition from 1.21.4 to 1.21.5 so this critical bug disappears. 
_If you want more information about this bug, please read my [comment](https://github.com/samolego/FabricTailor/issues/134#issuecomment-2795672521) and the [issue](https://github.com/samolego/FabricTailor/issues/134)_

# Heres an overview of this pull request:
An working instance of 2 clients (one using the mod and my actual minecraft account) and an server all running on InteliJ IDEA
![Image](https://github.com/user-attachments/assets/babea09a-9f70-445a-ab6a-3ecc36def4e5)
## I've managed to completely fix this issue. I've made a few changes.
### Gradle changes
* Gradle has been updated to 8.12 to support Loom 1.10.1 (Since it is an requirement for 1.21.5)
* I've updated the properties to fully move to 1.21.5
```gradle
# Done to increase the memory available to gradle.
org.gradle.jvmargs=-Xmx1G
# Fabric Properties
minecraft_version=1.21.5
yarn_mappings=1.21.5+build.1
loader_version=0.16.13

# Fabric API
fabric_version=0.119.9+1.21.5
# Mod Properties
mod_version=2.6.4
maven_group=org.samo_lego
archives_base_name=fabrictailor

# Dependencies
c2b_lib_version=2.0.1
carpet_core_version=1.21.5-1.4.169+v250325
permissions_api_version=0.3.3
```
### Code changes
* I was right about the NbtCompound stuff, but the documentation was a bit misleading and I needed to do some trial and error in order to fix the code.
```java
    @Inject(method = "readAdditionalSaveData", at = @At("TAIL"))
    private void readCustomDataFromNbt(CompoundTag tag, CallbackInfo ci) {
        CompoundTag skinDataTag = tag.getCompound("fabrictailor:skin_data").get();
        Optional<String> skinValueOP = skinDataTag.getString("value");
        Optional<String> skinSignatureOP = skinDataTag.getString("signature");
        // https://fabricmc.net/2025/03/24/1215.html#nbt
        if (skinValueOP.isEmpty() || skinSignatureOP.isEmpty()) {
            return;
        }

        this.skinValue = skinValueOP.get();
        this.skinSignature = skinSignatureOP.get();
        this.fabrictailor_setSkin(this.skinValue, this.skinSignature, false);
    }
```
* RenderSystem.enableBlend() is deprecated apparently, the function doesn't work
`src/main/java/org/samo_lego/fabrictailor/client/screen/SkinChangeScreen.java` [Go to file](https://github.com/samolego/FabricTailor/blob/af33ea9c3accbc52e96a882c6021201f6c993b0b/src/main/java/org/samo_lego/fabrictailor/client/screen/SkinChangeScreen.java#L234)
```java
 RenderSystem.enableBlend(); // This method doesn't exist anymore but I've seen no GUI issues, so it may be an deprecated feature that blends by default. So I've removed it from the code.
```
Since theres no issues from this deprecated method missing, there shouldn't be too much worry about this method. I'm just mentioning it.

# Status
This is confirmed to be working with evidence, please send a comment if you find any issues building or running this pull request.