### PR TITLE
feat: port to version 26.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id 'fabric-loom' version "${loom_version}"
+    id 'net.fabricmc.fabric-loom' version "${loom_version}"
     id 'maven-publish'
-    id "com.matthewprenger.cursegradle" version "1.4.0"
+    id "com.matthewprenger.cursegradle" version "1.4.0" apply false
     id "com.modrinth.minotaur" version "2.+"
 }
 
@@ -24,37 +24,46 @@ loom {
 }
 
 def ENV = System.getenv()
+def enableCurseforge = ENV.CURSEFORGE_API_KEY || gradle.startParameter.taskNames.any { it.toLowerCase().contains("curseforge") }
+
+if (enableCurseforge) {
+    apply plugin: "com.matthewprenger.cursegradle"
+}
 
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings loom.officialMojangMappings()
 
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-
-    // Config2Brigadier
-    modImplementation(include("com.github.samolego:Config2Brigadier:${project.c2b_lib_version}"))
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     // LuckPerms
-    modImplementation(include("me.lucko:fabric-permissions-api:${project.permissions_api_version}-patbox"))
+    implementation(include("me.lucko:fabric-permissions-api:${project.permissions_api_version}"))
 
     // Carpet
-    modCompileOnly("carpet:fabric-carpet:${project.carpet_core_version}")
+    compileOnly("carpet:fabric-carpet:${project.carpet_core_version}")
 }   
 
 processResources {
     inputs.property "version", project.version
+    inputs.property "loader_version", project.loader_version
+    inputs.property "minecraft_version", project.minecraft_version
+    inputs.property "fabric_version", project.fabric_version
 
     filesMatching("fabric.mod.json") {
-        expand "version": project.version
+        expand(
+                "version": project.version,
+                "loader_version": project.loader_version,
+                "minecraft_version": project.minecraft_version,
+                "fabric_version": project.fabric_version
+        )
     }
 }
 
 tasks.withType(JavaCompile).configureEach {
-    it.options.release = 21
+    it.options.release = 25
 }
 
 tasks.test {
@@ -95,35 +104,37 @@ publishing {
     }
 }
 
-// from FAPI https://github.com/FabricMC/fabric/blob/1.16/build.gradle
-curseforge {
-    if (ENV.CURSEFORGE_API_KEY) {
-        apiKey = ENV.CURSEFORGE_API_KEY
-    }
-
-    project {
-        id = "390114"
-        changelog = ENV.CHANGELOG ?: "A changelog can be found at https://github.com/samolego/FabricTailor/releases/tag/${version}"
-        releaseType = "release"
-        if (project.minecraft_version.contains("-")) {
-            // yuck
-            addGameVersion "${project.minecraft_version.split("-")[0]}-Snapshot"
-        } else {
-            addGameVersion "${project.minecraft_version}"
-        }
-        addGameVersion "Fabric"
-
-        mainArtifact(remapJar.archiveFile) {
-            displayName = "[${project.minecraft_version}] FabricTailor ${version}"
+if (enableCurseforge) {
+    // from FAPI https://github.com/FabricMC/fabric/blob/1.16/build.gradle
+    curseforge {
+        if (ENV.CURSEFORGE_API_KEY) {
+            apiKey = ENV.CURSEFORGE_API_KEY
         }
 
-        afterEvaluate {
-            uploadTask.dependsOn("remapJar")
-        }
-    }
+        project {
+            id = "390114"
+            changelog = ENV.CHANGELOG ?: "A changelog can be found at https://github.com/samolego/FabricTailor/releases/tag/${version}"
+            releaseType = "release"
+            if (project.minecraft_version.contains("-")) {
+                // yuck
+                addGameVersion "${project.minecraft_version.split("-")[0]}-Snapshot"
+            } else {
+                addGameVersion "${project.minecraft_version}"
+            }
+            addGameVersion "Fabric"
 
-    options {
-        forgeGradleIntegration = false
+            mainArtifact(jar.archiveFile) {
+                displayName = "[${project.minecraft_version}] FabricTailor ${version}"
+            }
+
+            afterEvaluate {
+                uploadTask.dependsOn("jar")
+            }
+        }
+
+        options {
+            forgeGradleIntegration = false
+        }
     }
 }
 
@@ -142,7 +153,7 @@ modrinth {
     versionName = "[${project.minecraft_version}] FabricTailor ${version}"
     versionType = "release"
 
-    uploadFile = remapJar.archiveFile
+    uploadFile = jar.archiveFile
 
     gameVersions = [project.minecraft_version]
     loaders = ['fabric', 'quilt']

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,12 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
-minecraft_version=1.21.11-rc2
-yarn_mappings=1.21.11-rc2+build.1
-loader_version=0.18.1
-loom_version=1.14-SNAPSHOT
+minecraft_version=26.1
+loader_version=0.18.5
+loom_version=1.15.5
 
 # Fabric API
-fabric_version=0.139.4+1.21.11
+fabric_version=0.144.3+26.1
 
 # Mod Properties
 mod_version=2.8.2
@@ -16,5 +15,5 @@ archives_base_name=fabrictailor
 
 # Dependencies
 c2b_lib_version=2.2.0
-carpet_core_version=1.21.10-1.4.188+v251016
-permissions_api_version=0.6.0
+carpet_core_version=26.1-beta-8+v260304
+permissions_api_version=0.7.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/samo_lego/fabrictailor/FabricTailor.java
+++ b/src/main/java/org/samo_lego/fabrictailor/FabricTailor.java
@@ -8,10 +8,6 @@ import net.fabricmc.fabric.api.networking.v1.ServerConfigurationConnectionEvents
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.Minecraft;
-import net.minecraft.server.MinecraftServer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.samo_lego.fabrictailor.command.FabrictailorCommand;
 import org.samo_lego.fabrictailor.command.SkinCommand;
 import org.samo_lego.fabrictailor.compatibility.CarpetFunctions;
@@ -42,7 +38,7 @@ public class FabricTailor implements ModInitializer {
 		});
 
 		configFile = new File(FabricLoader.getInstance().getConfigDir() + "/fabrictailor.json");
-		config = TailorConfig.loadConfigFile(configFile, FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER);
+		config = TailorConfig.loadConfigFile(configFile, isServerEnvironment());
 		config.save();
 
 		if (FabricLoader.getInstance().isModLoaded("carpet")) {
@@ -54,20 +50,24 @@ public class FabricTailor implements ModInitializer {
 		ServerConfigurationConnectionEvents.CONFIGURE.register(NetworkHandler::onConfigured);
 		
 		
-		PayloadTypeRegistry.configurationS2C().register(FabricTailorHelloPayload.TYPE, FabricTailorHelloPayload.CODEC);
+		PayloadTypeRegistry.clientboundConfiguration().register(FabricTailorHelloPayload.TYPE, FabricTailorHelloPayload.CODEC);
 
-		PayloadTypeRegistry.playC2S().register(VanillaSkinPayload.TYPE, VanillaSkinPayload.CODEC);
+		PayloadTypeRegistry.serverboundPlay().register(VanillaSkinPayload.TYPE, VanillaSkinPayload.CODEC);
 		ServerPlayNetworking.registerGlobalReceiver(VanillaSkinPayload.TYPE, NetworkHandler::changeVanillaSkinPacket);
 
-		PayloadTypeRegistry.playC2S().register(HDSkinPayload.TYPE, HDSkinPayload.CODEC);
+		PayloadTypeRegistry.serverboundPlay().register(HDSkinPayload.TYPE, HDSkinPayload.CODEC);
 		ServerPlayNetworking.registerGlobalReceiver(HDSkinPayload.TYPE, NetworkHandler::changeHDSkinPacket);
 
-		PayloadTypeRegistry.playC2S().register(DefaultSkinPayload.TYPE, DefaultSkinPayload.CODEC);
+		PayloadTypeRegistry.serverboundPlay().register(DefaultSkinPayload.TYPE, DefaultSkinPayload.CODEC);
 		ServerPlayNetworking.registerGlobalReceiver(DefaultSkinPayload.TYPE, NetworkHandler::defaultSkinPacket);
 	}
 
 	public static void reloadConfig() {
-		TailorConfig newConfig = TailorConfig.loadConfigFile(configFile, !Minecraft.getInstance().isLocalServer());
+		TailorConfig newConfig = TailorConfig.loadConfigFile(configFile, isServerEnvironment());
 		config.reload(newConfig);
+	}
+
+	private static boolean isServerEnvironment() {
+		return FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER;
 	}
 }

--- a/src/main/java/org/samo_lego/fabrictailor/client/ClientTailor.java
+++ b/src/main/java/org/samo_lego/fabrictailor/client/ClientTailor.java
@@ -5,7 +5,7 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientConfigurationNetworking;
 import net.fabricmc.fabric.api.client.networking.v1.ClientLoginConnectionEvents;
 import net.minecraft.ChatFormatting;
@@ -38,7 +38,7 @@ public class ClientTailor implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
-        keyBinding = KeyBindingHelper.registerKeyBinding(new KeyMapping(
+        keyBinding = KeyMappingHelper.registerKeyMapping(new KeyMapping(
                 "key.fabrictailor.toggle_skin_gui",
                 InputConstants.Type.KEYSYM,
                 GLFW.GLFW_KEY_K, // K for opening the window
@@ -50,7 +50,7 @@ public class ClientTailor implements ClientModInitializer {
                 if (TAILORED_SERVER || forceOpen) {
                     client.setScreen(SKIN_CHANGE_SCREEN);
                 } else {
-                    client.player.displayClientMessage(TextTranslations.create("error.fabrictailor.not_installed").withStyle(ChatFormatting.RED), false);
+                    client.player.sendSystemMessage(TextTranslations.create("error.fabrictailor.not_installed").withStyle(ChatFormatting.RED));
                     forceOpen = true;
                 }
             }

--- a/src/main/java/org/samo_lego/fabrictailor/client/screen/SkinChangeScreen.java
+++ b/src/main/java/org/samo_lego/fabrictailor/client/screen/SkinChangeScreen.java
@@ -7,15 +7,13 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Checkbox;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
-import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
-import net.minecraft.client.gui.screens.inventory.tooltip.DefaultTooltipPositioner;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
@@ -98,7 +96,7 @@ public class SkinChangeScreen extends Screen {
         this.addRenderableWidget(openExplorerButton);
         if (this.font == null) {  // todo: figure out why this happens in 1.21.11
             Minecraft.getInstance().setScreen(null);
-            Minecraft.getInstance().player.displayClientMessage(Component.nullToEmpty("WTH?? Screen#font is null, closing screen"), false);
+            Minecraft.getInstance().player.sendSystemMessage(Component.nullToEmpty("WTH?? Screen#font is null, closing screen"));
             return;
         }
 
@@ -121,7 +119,7 @@ public class SkinChangeScreen extends Screen {
         skinInput.setVisible(true);
         skinInput.setBordered(true);
         skinInput.setTextColor(0xFFFFFFFF);
-        this.addWidget(skinInput);
+        this.addRenderableWidget(skinInput);
 
         // "Set skin" button
         this.addRenderableWidget(
@@ -229,11 +227,11 @@ public class SkinChangeScreen extends Screen {
      * Renders the skin changing screen.
      */
     @Override
-    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float delta) {
-        super.render(guiGraphics, mouseX, mouseY, delta);
+    public void extractRenderState(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float delta) {
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta);
 
         // Screen title
-        guiGraphics.drawCenteredString(this.font, title, width / 2, 15, -1);
+        guiGraphics.centeredText(this.font, title, width / 2, 15, -1);
 
         // Starting position of the window texture
         this.startX = (this.width - 252) / 2;
@@ -241,9 +239,6 @@ public class SkinChangeScreen extends Screen {
 
         // Window texture
         guiGraphics.blit(RenderPipelines.GUI_TEXTURED, AAdvancementsScreen.getWINDOW_LOCATION(), startX, startY, 0, 0, 252, 140, 256, 256);
-
-
-        this.skinInput.render(guiGraphics, startX, startY, delta);
 
         // Other renders
         this.drawTabs(guiGraphics, startX, startY);
@@ -257,11 +252,11 @@ public class SkinChangeScreen extends Screen {
         } else {
             // Drawing Player
             // Luckily vanilla code is available
-            InventoryScreen.renderEntityInInventoryFollowsMouse(guiGraphics, x, y, x + 75, y + 208, 48, 1.0f, mouseX + 2, mouseY - 16, this.minecraft.player);
+            InventoryScreen.extractEntityInInventoryFollowsMouse(guiGraphics, x, y, x + 75, y + 208, 48, 1.0f, mouseX + 2, mouseY - 16, this.minecraft.player);
         }
     }
 
-    public void renderEntityInInventoryFollowsMouseBackwards(GuiGraphics guiGraphics, int i, int j, int k, int l, int m, float f, float g, float h, LivingEntity livingEntity) {
+    public void renderEntityInInventoryFollowsMouseBackwards(GuiGraphicsExtractor guiGraphics, int i, int j, int k, int l, int m, float f, float g, float h, LivingEntity livingEntity) {
         float mousex = -(((float) width / 2) - 75 - g);
         float mousey = ((float) height / 2) - h;
         float p = (float) Math.atan(mousex / 40.0f);
@@ -299,7 +294,7 @@ public class SkinChangeScreen extends Screen {
         }
 
         Vector3f vector3f = new Vector3f(0.0F, entityRenderState.boundingBoxHeight / 2.0F + f, 0.0F);
-        guiGraphics.submitEntityRenderState(entityRenderState, (float)m, vector3f, quaternionf, quaternionf2, i, j, k, l);
+        guiGraphics.entity(entityRenderState, (float) m, vector3f, quaternionf, quaternionf2, i, j, k, l);
         livingEntity.yBodyRot = r;
         livingEntity.setYRot(s);
         livingEntity.setXRot(t);
@@ -315,7 +310,7 @@ public class SkinChangeScreen extends Screen {
      * @param startX      x where skin window starts
      * @param startY      y where skin window starts
      */
-    private void drawTabs(GuiGraphics guiGraphics, int startX, int startY) {
+    private void drawTabs(GuiGraphicsExtractor guiGraphics, int startX, int startY) {
         if (this.selectedTab == null) {
             this.selectedTab = TABS.get(0);
         }
@@ -332,14 +327,14 @@ public class SkinChangeScreen extends Screen {
                 this.openExplorerButton.visible = tab.showExplorerButton();
             }
 
-            tab.getTabType().draw(guiGraphics, startX, startY, selected, tab.getTabType().getMax() - i - 1);
+            tab.getTabType().extractRenderState(guiGraphics, startX, startY, selected, tab.getTabType().getMax() - i - 1);
         }
 
         // Rendering title
-        guiGraphics.drawString(this.font, this.selectedTab.getTitle(), startX + 10, startY + 5, 0xFFFFFFFF);
+        guiGraphics.text(this.font, this.selectedTab.getTitle(), startX + 10, startY + 5, 0xFFFFFFFF);
 
         // Rendering description above input field
-        guiGraphics.drawString(this.font, this.selectedTab.getDescription(), width / 2, height / 2 - 40, 0xFFFFFFFF);
+        guiGraphics.text(this.font, this.selectedTab.getDescription(), width / 2, height / 2 - 40, 0xFFFFFFFF);
     }
 
 
@@ -349,11 +344,11 @@ public class SkinChangeScreen extends Screen {
      * @param startX x where skin window starts
      * @param startY y where skin window starts
      */
-    private void drawIcons(GuiGraphics guiGraphics, int startX, int startY) {
+    private void drawIcons(GuiGraphicsExtractor guiGraphics, int startX, int startY) {
         // Icons
         for (int i = 0; i < TABS.size(); ++i) {
             SkinTabType tab = TABS.get(i);
-            tab.getTabType().drawIcon(guiGraphics, startX, startY, tab.getTabType().getMax() - i - 1, tab.getIcon());
+            tab.getTabType().extractIcon(guiGraphics, startX, startY, tab.getTabType().getMax() - i - 1, tab.getIcon());
         }
     }
 
@@ -367,13 +362,12 @@ public class SkinChangeScreen extends Screen {
      * @param mouseX      mouse x
      * @param mouseY      mouse y
      */
-    private void drawWidgetTooltips(GuiGraphics guiGraphics, int startX, int startY, int mouseX, int mouseY) {
+    private void drawWidgetTooltips(GuiGraphicsExtractor guiGraphics, int startX, int startY, int mouseX, int mouseY) {
         for (int i = 0; i < TABS.size(); ++i) {
             SkinTabType tab = TABS.get(i);
 
-            ClientTooltipComponent clientTooltipComponent = ClientTooltipComponent.create(tab.getTitle().getVisualOrderText());
             if (tab.getTabType().isMouseOver(startX, startY, tab.getTabType().getMax() - i - 1, mouseX, mouseY)) {
-                guiGraphics.renderTooltip(this.font, List.of(clientTooltipComponent), mouseX, mouseY, DefaultTooltipPositioner.INSTANCE, null);
+                guiGraphics.setTooltipForNextFrame(this.font, tab.getTitle(), mouseX, mouseY);
                 break;
             }
         }

--- a/src/main/java/org/samo_lego/fabrictailor/command/SkinCommand.java
+++ b/src/main/java/org/samo_lego/fabrictailor/command/SkinCommand.java
@@ -130,7 +130,7 @@ public class SkinCommand {
         // Warn about server path for uploads
         MinecraftServer server = player.level().getServer();
         if (server != null && server.isDedicatedServer() && config.logging.skinChangeFeedback) {
-                player.displayClientMessage(
+                player.sendSystemMessage(
                     TextTranslations.create("hint.fabrictailor.server_skin_path").withStyle(ChatFormatting.GOLD),
                     false
             );
@@ -139,7 +139,7 @@ public class SkinCommand {
         setSkin(player, () -> setSkinFromFile(skinFilePath, useSlim));
         
         if (config.logging.skinChangeFeedback) {
-            player.displayClientMessage(TextTranslations.create("command.fabrictailor.skin.please_wait").withStyle(ChatFormatting.GOLD),
+            player.sendSystemMessage(TextTranslations.create("command.fabrictailor.skin.please_wait").withStyle(ChatFormatting.GOLD),
                     false
             );
         }
@@ -168,17 +168,17 @@ public class SkinCommand {
         long now = System.currentTimeMillis();
 
         if (now - lastChange > config.skinChangeTimer * 1000 || lastChange == 0) {
-            player.displayClientMessage(SET_SKIN_ATTEMPT.withStyle(ChatFormatting.AQUA), false);
+            player.sendSystemMessage(SET_SKIN_ATTEMPT.withStyle(ChatFormatting.AQUA), false);
             THREADPOOL.submit(() -> {
                 var skinData = skinProvider.get();
 
                 if (skinData.isEmpty()) {
-                    player.displayClientMessage(SKIN_SET_ERROR, false);
+                    player.sendSystemMessage(SKIN_SET_ERROR, false);
                 } else {
                     ((TailoredPlayer) player).fabrictailor_setSkin(skinData.get(), true);
                     
                     if (config.logging.skinChangeFeedback) {
-                        player.displayClientMessage(TextTranslations.create("command.fabrictailor.skin.set.success").withStyle(ChatFormatting.GREEN), false);
+                        player.sendSystemMessage(TextTranslations.create("command.fabrictailor.skin.set.success").withStyle(ChatFormatting.GREEN), false);
                     }
                 }
             });
@@ -186,7 +186,7 @@ public class SkinCommand {
             // Prevent skin change spamming
             MutableComponent timeLeft = Component.literal(String.valueOf((config.skinChangeTimer * 1000 - now + lastChange) / 1000))
                     .withStyle(ChatFormatting.LIGHT_PURPLE);
-            player.displayClientMessage(
+            player.sendSystemMessage(
                     TextTranslations.create("command.fabrictailor.skin.timer.please_wait", timeLeft)
                             .withStyle(ChatFormatting.RED),
                     false
@@ -203,7 +203,7 @@ public class SkinCommand {
         if (now - lastChange > config.skinChangeTimer * 1000 || lastChange == 0) {
             ((TailoredPlayer) player).fabrictailor_clearSkin();
             if (config.logging.skinChangeFeedback) {
-                player.displayClientMessage(
+                player.sendSystemMessage(
                         TextTranslations.create("command.fabrictailor.skin.clear.success").withStyle(ChatFormatting.GREEN),
                         false
                 );
@@ -215,7 +215,7 @@ public class SkinCommand {
         // Prevent skin change spamming
         MutableComponent timeLeft = Component.literal(String.valueOf((config.skinChangeTimer * 1000 - now + lastChange) / 1000))
                 .withStyle(ChatFormatting.LIGHT_PURPLE);
-        player.displayClientMessage(
+        player.sendSystemMessage(
                 TextTranslations.create("command.fabrictailor.skin.timer.please_wait", timeLeft)
                         .withStyle(ChatFormatting.RED),
                 false

--- a/src/main/java/org/samo_lego/fabrictailor/config/TailorConfig.java
+++ b/src/main/java/org/samo_lego/fabrictailor/config/TailorConfig.java
@@ -3,10 +3,6 @@ package org.samo_lego.fabrictailor.config;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
-import jdk.jshell.execution.Util;
-import org.samo_lego.config2brigadier.common.IBrigadierConfigurator;
-import org.samo_lego.config2brigadier.common.annotation.BrigadierDescription;
-import org.samo_lego.config2brigadier.common.annotation.BrigadierExcluded;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -16,13 +12,12 @@ import java.util.Set;
 import static org.samo_lego.fabrictailor.FabricTailor.*;
 import static org.samo_lego.fabrictailor.util.Logging.error;
 
-public class TailorConfig implements IBrigadierConfigurator {
+public class TailorConfig {
     private static final Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().disableHtmlEscaping().create();
 
 
     @SerializedName("// Whether to allow players to have capes. WARNING! This will toggle ALL capes!")
     public final String _comment_allowCapes = "(default: true)";
-    @BrigadierDescription(defaultOption = "true")
     @SerializedName("allow_capes")
     public boolean allowCapes = true;
     
@@ -31,13 +26,11 @@ public class TailorConfig implements IBrigadierConfigurator {
     public static class Logging {
         @SerializedName("// Whether to send (successful) command feedback for skin changes. Errors are sent regardless.")
         public final String _comment_skinChangeFeedback = "(default: true)";
-        @BrigadierDescription(defaultOption = "true")
         @SerializedName("skin_change_feedback")
         public boolean skinChangeFeedback = true;
 
         @SerializedName("// Whether to send debug messages to console.")
         public final String _comment_debug = "(default: false)";
-        @BrigadierDescription(defaultOption = "false")
         public boolean debug = false;
     }
 
@@ -48,7 +41,6 @@ public class TailorConfig implements IBrigadierConfigurator {
 
     @SerializedName("// How quickly can player change the skin, in seconds. -1 for no limit. If using this in server environment, -1 is not recommended.")
     public final String _comment_skinChangeTimer = "(default in singleplayer: -1, default for server: 60)";
-    @BrigadierDescription(defaultOption = "-1")
     @SerializedName("skin_change_timer")
     public long skinChangeTimer = -1;
 
@@ -58,7 +50,6 @@ public class TailorConfig implements IBrigadierConfigurator {
     public final String _comment_customSkinServer1 = "";
     @SerializedName("// Available parameters: {player}. Example: https://skins.samolego.org/{player}.png. Skins returned need to be 64x64!")
     public final String _comment_customSkinServer2 = "";
-    @BrigadierDescription(defaultOption = "")
     @SerializedName("custom_skin_server")
     public String customSkinServer = "";
 
@@ -80,7 +71,6 @@ public class TailorConfig implements IBrigadierConfigurator {
             "duckduckgo.com"
     ));
 
-    @Override
     public void save() {
         try (Writer writer = new OutputStreamWriter(new FileOutputStream(configFile), StandardCharsets.UTF_8)) {
             gson.toJson(this, writer);
@@ -93,12 +83,9 @@ public class TailorConfig implements IBrigadierConfigurator {
     public static class DefaultSkin {
         @SerializedName("// Whether to apply the default skin to ALL new players, not just those without skin.")
         public final String _comment_applyToAll = "(default: false)";
-        @BrigadierDescription(defaultOption = "false")
         @SerializedName("apply_to_all")
         public boolean applyToAll = false;
-        @BrigadierExcluded
         public String value = "";
-        @BrigadierExcluded
         public String signature = "";
     }
 
@@ -106,20 +93,71 @@ public class TailorConfig implements IBrigadierConfigurator {
      * Loads config file.
      *
      * @param file file to load the language file from.
-     * @return TaterzenLanguage object
+     * @return Tailor config object
      */
     public static TailorConfig loadConfigFile(File file, boolean serverEnvironment) {
-        return IBrigadierConfigurator.loadConfigFile(file, TailorConfig.class, () -> {
-            // Config doesn't exist yet
-            var config = new TailorConfig();
-            if (serverEnvironment) {
-                // A bit different default config
-                config.skinChangeTimer = 60;
-            } else {
-                config.defaultSkin.applyToAll = true;
+        TailorConfig defaults = createDefault(serverEnvironment);
+
+        if (!file.exists()) {
+            return defaults;
+        }
+
+        try (Reader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {
+            TailorConfig loaded = gson.fromJson(reader, TailorConfig.class);
+            if (loaded == null) {
+                return defaults;
             }
 
-            return config;
-        });
+            loaded.applyDefaults(defaults);
+            return loaded;
+        } catch (Exception e) {
+            error("Problem occurred when loading config: " + e.getMessage());
+            return defaults;
+        }
+    }
+
+    public void reload(TailorConfig newConfig) {
+        this.allowCapes = newConfig.allowCapes;
+        this.logging = newConfig.logging;
+        this.defaultSkin = newConfig.defaultSkin;
+        this.skinChangeTimer = newConfig.skinChangeTimer;
+        this.customSkinServer = newConfig.customSkinServer;
+        this.allowedTextureDomains = new HashSet<>(newConfig.allowedTextureDomains);
+    }
+
+    private static TailorConfig createDefault(boolean serverEnvironment) {
+        var config = new TailorConfig();
+        if (serverEnvironment) {
+            config.skinChangeTimer = 60;
+        } else {
+            config.defaultSkin.applyToAll = true;
+        }
+
+        return config;
+    }
+
+    private void applyDefaults(TailorConfig defaults) {
+        if (this.logging == null) {
+            this.logging = defaults.logging;
+        }
+
+        if (this.defaultSkin == null) {
+            this.defaultSkin = defaults.defaultSkin;
+        } else {
+            if (this.defaultSkin.value == null) {
+                this.defaultSkin.value = defaults.defaultSkin.value;
+            }
+            if (this.defaultSkin.signature == null) {
+                this.defaultSkin.signature = defaults.defaultSkin.signature;
+            }
+        }
+
+        if (this.customSkinServer == null) {
+            this.customSkinServer = defaults.customSkinServer;
+        }
+
+        if (this.allowedTextureDomains == null || this.allowedTextureDomains.isEmpty()) {
+            this.allowedTextureDomains = new HashSet<>(defaults.allowedTextureDomains);
+        }
     }
 }

--- a/src/main/java/org/samo_lego/fabrictailor/network/NetworkHandler.java
+++ b/src/main/java/org/samo_lego/fabrictailor/network/NetworkHandler.java
@@ -75,7 +75,7 @@ public class NetworkHandler {
             config.save();
 
             if (config.logging.skinChangeFeedback) {
-                context.player().displayClientMessage(TextTranslations.create("command.fabrictailor.config.defaultSkin")
+                context.player().sendSystemMessage(TextTranslations.create("command.fabrictailor.config.defaultSkin")
                         .withStyle(ChatFormatting.GREEN), false);
             }
         }
@@ -84,7 +84,7 @@ public class NetworkHandler {
     public static void changeHDSkinPacket(HDSkinPayload payload, Context context) {
         NetworkHandler.onSkinChangePacket(context.player(), payload.skinProperty(), () -> {
                 if (config.logging.skinChangeFeedback) {
-                    context.player().displayClientMessage(TextTranslations.create("hint.fabrictailor.client_only")
+                    context.player().sendSystemMessage(TextTranslations.create("hint.fabrictailor.client_only")
                             .withStyle(ChatFormatting.DARK_PURPLE), false);
                 }
             });
@@ -102,7 +102,7 @@ public class NetworkHandler {
             // Prevent skin change spamming
             MutableComponent timeLeft = Component.literal(String.valueOf((config.skinChangeTimer * 1000 - now + lastChange) / 1000))
                     .withStyle(ChatFormatting.LIGHT_PURPLE);
-            player.displayClientMessage(
+            player.sendSystemMessage(
                     TextTranslations.create("command.fabrictailor.skin.timer.please_wait", timeLeft)
                             .withStyle(ChatFormatting.RED),
                     false

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,8 +31,9 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.8.8",
-    "fabric": "*"
+    "fabricloader": ">=${loader_version}",
+    "minecraft": "~${minecraft_version}",
+    "fabric-api": ">=${fabric_version}"
   },
   "custom": {
     "modmenu": {

--- a/src/main/resources/fabrictailor.accesswidener
+++ b/src/main/resources/fabrictailor.accesswidener
@@ -1,3 +1,3 @@
-accessWidener v2 named
+accessWidener v2 official
 
 accessible class net/minecraft/client/gui/screens/advancements/AdvancementTabType

--- a/src/test/java/org/samo_lego/fabrictailor/testmod/TailorTest.java
+++ b/src/test/java/org/samo_lego/fabrictailor/testmod/TailorTest.java
@@ -4,8 +4,8 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
@@ -37,7 +37,7 @@ public class TailorTest implements ModInitializer, ClientModInitializer {
     }
 
     private void hdSkinCmd(CommandDispatcher<FabricClientCommandSource> dispatcher) {
-        dispatcher.register(ClientCommandManager.literal("hdskin").executes(this::hdSkinCmd));
+        dispatcher.register(ClientCommands.literal("hdskin").executes(this::hdSkinCmd));
     }
 
     private int hdSkinCmd(CommandContext<FabricClientCommandSource> context) {
@@ -47,7 +47,7 @@ public class TailorTest implements ModInitializer, ClientModInitializer {
     }
 
     private void capeCmd(CommandDispatcher<FabricClientCommandSource> dispatcher) {
-        dispatcher.register(ClientCommandManager.literal("cape").executes(this::capeCmd));
+        dispatcher.register(ClientCommands.literal("cape").executes(this::capeCmd));
     }
 
     private int capeCmd(CommandContext<FabricClientCommandSource> context) {

--- a/src/test/resources/fabric.mod.json
+++ b/src/test/resources/fabric.mod.json
@@ -29,8 +29,9 @@
   "mixins": [ ],
 
   "depends": {
-    "fabricloader": ">=0.8.8",
-    "fabric": "*"
+    "fabricloader": ">=${loader_version}",
+    "minecraft": "~${minecraft_version}",
+    "fabric-api": ">=${fabric_version}"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
Hi friends,

I needed a port for my personal server, so in case you also find this helpful I'll summarize the changes:

- I updated Loom / Loader / Fabric API / Gradle versions for 26.1
- switched the build config to the new 26.1 deobfuscated ways of Mojang  
  - `net.fabricmc.fabric-loom`
  - remove `mappings`
  - replace `modImplementation` / `modCompileOnly` with `implementation` / `compileOnly`
  - replace `remapJar` publishing targets with `jar`
- moved the project to Java 25
- update Fabric API usages renamed in 26.1
  - networking payload registry methods
  - key mapping helper
  - client command API
  - screen/render extraction methods
- update access widener namespace to `official`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime configuration reload capability

* **Chores**
  * Updated to support Minecraft 26.1 and Fabric 0.144.3
  * Upgraded Java compilation target to 25
  * Updated build infrastructure and dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->